### PR TITLE
Disallow prototype path override - checking magic attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@
 
 var isArray = require('@fav/type.is-array');
 
+var disallowProtoPath = function(path, value) {
+  if (value === Object.prototype) {
+    throw new Error("Unsafe path encountered: " + path);
+  }
+}
+
 function setDeep(obj, propPath, value) {
   if (arguments.length < 3) {
     return;
@@ -28,6 +34,7 @@ function setDeep(obj, propPath, value) {
     if (!canHaveProp(child)) {
       break;
     }
+    disallowProtoPath(existentProp, child);
     obj = child;
   }
 

--- a/test/set-deep.test.js
+++ b/test/set-deep.test.js
@@ -416,4 +416,11 @@ describe('fav.prop.set-deep', function() {
       expect(obj[de]).to.equal(30);
     }
   });
+
+  it('should not allow proto path overwrite', function() {
+    var obj = {};
+    expect(function() { setDeep(obj, ["__proto__", "polluted"], "Yes, its polluted") }).to.throw();
+    expect(function() { setDeep(obj, ["constructor", "prototype", "polluted"], "Yes, its polluted") }).to.throw();
+    expect(function() { setDeep(Object, ["prototype", "polluted"], "Yes, its polluted") }).to.throw();
+  })
 });


### PR DESCRIPTION
### 📊 Metadata *

`@fav/prop.set-deep` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40fav%2Fprop.set-deep/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function throws exception, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var setDeep = require("@fav/prop.set-deep")

var obj = {};
console.log("Before: " + {}.polluted);
setDeep(obj, ["__proto__", "polluted"], "Yes, its polluted")
console.log("After: ", {}.polluted);
```

2. Execute the following commands in the terminal:

```
npm i @fav/prop.set-deep # install vulnerable package
node poc.js # run the PoC
```

3. Check the output:

```
Before: undefined
After: Yes, its polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/107146977-73cd7e00-6971-11eb-8618-d32b07c17968.png)

After:
![image](https://user-images.githubusercontent.com/64132745/107146936-3a950e00-6971-11eb-9523-14b9adff71ad.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.
![image](https://user-images.githubusercontent.com/64132745/107146951-57314600-6971-11eb-8747-64d672c896a4.png)

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1853
